### PR TITLE
Pyth index update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ spl-token = {version = "3.0.1", features = ["no-entrypoint"]}
 arrayref = "0.3.6"
 borsh = "0.8.2"
 uint = "0.8"
-
+pyth-client = "0.1.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -99,6 +99,13 @@ pub enum PerpetualSwapInstruction {
     /// 2. `[]` user transfer authority
     /// 3. `[]` The token program
     UpdatePrices { index_price: f64, mark_price: f64 },
+
+    /// Accounts expected:
+    /// 0. `[w]` PerpetualSwap
+    /// 1. `[]` Pyth product info
+    /// 2. `[]` Pyth Price Info
+    OracleUpdateIndex {},
+
 }
 
 impl PerpetualSwapInstruction {
@@ -151,6 +158,7 @@ impl PerpetualSwapInstruction {
                     mark_price,
                 }
             }
+            7 => Self::OracleUpdateIndex{},
             _ => return Err(PerpetualSwapError::InvalidInstruction.into()),
         })
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -98,7 +98,9 @@ pub enum PerpetualSwapInstruction {
     /// 1. `[]` swap authority
     /// 2. `[]` user transfer authority
     /// 3. `[]` The token program
-    UpdatePrices { index_price: f64, mark_price: f64 },
+    /// 4. `[]` Pyth product info
+    /// 5. `[]` Pyth Price Info
+    UpdatePrices { mark_price: f64 },
 
     /// Accounts expected:
     /// 0. `[w]` PerpetualSwap
@@ -150,11 +152,9 @@ impl PerpetualSwapInstruction {
             }
             5 => Self::TransferFunds {},
             6 => {
-                let (index_price, _rest) = Self::unpack_fn::<f64>(rest)?;
                 let (mark_price, _rest) = Self::unpack_fn::<f64>(rest)?;
 
                 Self::UpdatePrices {
-                    index_price,
                     mark_price,
                 }
             }


### PR DESCRIPTION
split the process oracle update public instruction/processor function into 2 processor functions and set up update prices to automatically fetch from pyth instead of requiring both numbers as arguments